### PR TITLE
Replace DynamoDBCrudPolicy with least-privilege IAM policies

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -18,8 +18,12 @@ Resources:
       Tracing: Active
       Policies:
         - AWSXrayWriteOnlyAccess
-        - DynamoDBCrudPolicy:
-            TableName: !Ref notesTable
+        - Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:Scan
+              Resource: !GetAtt notesTable.Arn
       Environment:
         Variables:
           TABLE_NAME: !Ref notesTable
@@ -50,8 +54,12 @@ Resources:
       Tracing: Active
       Policies:
         - AWSXrayWriteOnlyAccess
-        - DynamoDBCrudPolicy:
-            TableName: !Ref notesTable
+        - Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:PutItem
+              Resource: !GetAtt notesTable.Arn
       Environment:
         Variables:
           TABLE_NAME: !Ref notesTable
@@ -95,8 +103,12 @@ Resources:
       Tracing: Active
       Policies:
         - AWSXrayWriteOnlyAccess
-        - DynamoDBCrudPolicy:
-            TableName: !Ref notesTable
+        - Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:GetItem
+              Resource: !GetAtt notesTable.Arn
       Environment:
         Variables:
           TABLE_NAME: !Ref notesTable
@@ -127,8 +139,12 @@ Resources:
       Tracing: Active
       Policies:
         - AWSXrayWriteOnlyAccess
-        - DynamoDBCrudPolicy:
-            TableName: !Ref notesTable
+        - Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:UpdateItem
+              Resource: !GetAtt notesTable.Arn
       Environment:
         Variables:
           TABLE_NAME: !Ref notesTable
@@ -159,8 +175,12 @@ Resources:
       Tracing: Active
       Policies:
         - AWSXrayWriteOnlyAccess
-        - DynamoDBCrudPolicy:
-            TableName: !Ref notesTable
+        - Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:DeleteItem
+              Resource: !GetAtt notesTable.Arn
       Environment:
         Variables:
           TABLE_NAME: !Ref notesTable


### PR DESCRIPTION
This pull request was generated by @kiro-agent :ghost:
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Overview
This PR replaces the broad SAM `DynamoDBCrudPolicy` with custom IAM policies that follow the principle of least privilege for each Lambda function.

## Changes Made
Replaced `DynamoDBCrudPolicy` with custom inline IAM policies for all Lambda functions in `template.yaml`:

- **List Function** (`src/list/index.js`): Grants only `dynamodb:Scan` permission
- **Create Function** (`src/create/index.js`): Grants only `dynamodb:PutItem` permission
- **Get Function** (`src/get/index.js`): Grants only `dynamodb:GetItem` permission
- **Update Function** (`src/update/index.js`): Grants only `dynamodb:UpdateItem` permission
- **Remove Function** (`src/remove/index.js`): Grants only `dynamodb:DeleteItem` permission

Each policy:
- Specifies only the exact DynamoDB action needed for that function
- References the exact DynamoDB table ARN using `!GetAtt notesTable.Arn`
- Uses simple, minimal IAM policy statements that are easy to understand and maintain

## Benefits
- **Enhanced Security**: Each Lambda function now has only the specific DynamoDB permissions it needs, reducing the attack surface
- **Least Privilege**: Follows security best practices by granting minimum necessary permissions
- **Better Auditability**: Clear visibility into what each function can do with the DynamoDB table
- **Simplified Troubleshooting**: Easier to identify permission-related issues when each function has explicit permissions

## Testing
No functional changes were made to the application code. The Lambda functions will continue to work as before, but with more restrictive IAM permissions that match their actual usage patterns.

fixes #17 